### PR TITLE
fix: jq syntax correction

### DIFF
--- a/bash/docker-credential-1password
+++ b/bash/docker-credential-1password
@@ -52,7 +52,7 @@ function get {
   jq --arg registry $registry '{
 		ServerURL: $registry, 
 		Username: (.fields|map(select(.id == "username")|.value)|.[0]), 
-		Secret: (.fields|map(select(.id == "credential")|.value).[0])
+		Secret: (.fields|map(select(.id == "credential")|.value)|.[0])
          }' <<< "$credentials"
 }
 


### PR DESCRIPTION
Not sure if this is a typo or a change in `jq` or `op`, but if it is helpful fix for others I thought I would ship it back. 

Thanks for writing a super helpful tool!

Omitting the pip in credential causes the error
```~ ❯ docker-credential-1password get <<< secretregistry.com
jq: error: syntax error, unexpected '[', expecting FORMAT or QQSTRING_START (Unix shell quoting issues?) at <top-level>, line 4:
                Secret: (.fields|map(select(.id == "credential")|.value).[0])
jq: 1 compile error```

Adding the | into the selector fixes the issue.